### PR TITLE
Changes needed to read in Scott's reference catalog data

### DIFF
--- a/config/filterMap.py
+++ b/config/filterMap.py
@@ -1,1 +1,1 @@
-config.filterMap = {'lsst_{}_smeared'.format(band): band for band in 'ugrizy'}
+config.filterMap = {band: 'lsst_{}_smeared'.format(band) for band in 'ugrizy'}

--- a/config/filterMap.py
+++ b/config/filterMap.py
@@ -1,0 +1,1 @@
+config.filterMap = {'lsst_{}_smeared'.format(band): band for band in 'ugrizy'}

--- a/config/processEimage.py
+++ b/config/processEimage.py
@@ -1,9 +1,12 @@
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 import os.path
 from lsst.utils import getPackageDir
-config.charImage.refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-config.calibrate.astromRefObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-config.calibrate.photoRefObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+# Astrometry (copied from lsst:obs_subaru/config/processCcd.py)
+for refObjLoader in (config.charImage.refObjLoader,
+                     config.calibrate.astromRefObjLoader,
+                     config.calibrate.photoRefObjLoader):
+    refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+    refObjLoader.load(os.path.join(getPackageDir('obs_lsstSim'), 'config', 'filterMap.py'))
 
 config.charImage.repair.doCosmicRay=True
 


### PR DESCRIPTION
Opening this PR so that further changes can be discussed.   [As noted](https://lsstc.slack.com/archives/C77DDKZHR/p1519340864000002) in the #desc-dc2 Slack channel, this now fails with
```
Traceback (most recent call last):
  File "/global/cscratch1/sd/jchiang8/DC2/phosim_Run1.1p/obs_lsstSim/bin/processEimage.py", line 25, in <module>
    ProcessEimageTask.parseAndRun()
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/cmdLineTask.py", line 586, in parseAndRun
    resultList = taskRunner.run(parsedCmd)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/cmdLineTask.py", line 240, in run
    resultList = list(mapFunc(self, targetList))
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/cmdLineTask.py", line 405, in __call__
    result = task.run(dataRef, **kwargs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/timer.py", line 150, in wrapper
    res = func(self, *args, **keyArgs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_tasks/14.0-47-gd71a8703/python/lsst/pipe/tasks/processCcd.py", line 199, in run
    icSourceCat=charRes.sourceCat,
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/timer.py", line 150, in wrapper
    res = func(self, *args, **keyArgs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_tasks/14.0-47-gd71a8703/python/lsst/pipe/tasks/calibrate.py", line 433, in run
    icSourceCat=icSourceCat,
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_tasks/14.0-47-gd71a8703/python/lsst/pipe/tasks/calibrate.py", line 522, in calibrate
    sourceCat=sourceCat,
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/timer.py", line 150, in wrapper
    res = func(self, *args, **keyArgs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/meas_astrom/14.0-7-g0d69b06/python/lsst/meas/astrom/astrometry.py", line 188, in run
    res = self.solve(exposure=exposure, sourceCat=sourceCat)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/timer.py", line 150, in wrapper
    res = func(self, *args, **keyArgs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/meas_astrom/14.0-7-g0d69b06/python/lsst/meas/astrom/astrometry.py", line 214, in solve
    calib=expMd.calib,
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/timer.py", line 150, in wrapper
    res = func(self, *args, **keyArgs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/meas_algorithms/14.0-15-gaf93ae82/python/lsst/meas/algorithms/loadReferenceObjects.py", line 212, in loadPixelBox
    loadRes = self.loadSkyCircle(circle.coord, circle.radius, filterName)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/pipe_base/14.0-6-ge2c9487+43/python/lsst/pipe/base/timer.py", line 150, in wrapper
    res = func(self, *args, **keyArgs)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/meas_algorithms/14.0-15-gaf93ae82/python/lsst/meas/algorithms/loadIndexedReferenceObjects.py", line 77, in loadSkyCircle
    self._addFluxAliases(refCat.schema)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/meas_algorithms/14.0-15-gaf93ae82/python/lsst/meas/algorithms/loadReferenceObjects.py", line 301, in _addFluxAliases
    addAliasesForOneFilter(filterName, refFilterName)
  File "/global/cscratch1/sd/desc/lsstsw/stack/stack/miniconda3-4.3.21-10a4fa6/Linux64/meas_algorithms/14.0-15-gaf93ae82/python/lsst/meas/algorithms/loadReferenceObjects.py", line 290, in addAliasesForOneFilter
    raise RuntimeError("Unknown reference filter %s" % (refFluxName,))
RuntimeError: Unknown reference filter u_flux
```