### PR TITLE
Fixing test_getId after updates and cleaning up some flake errors in …

### DIFF
--- a/python/lsst/obs/lsstSim/lsstSimMapper.py
+++ b/python/lsst/obs/lsstSim/lsstSimMapper.py
@@ -1,4 +1,3 @@
-from builtins import map
 from past.builtins import basestring
 #
 # LSST Data Management System
@@ -80,10 +79,9 @@ class LsstSimMapper(CameraMapper):
         LsstSimMapper._nbit_tract = 16
         LsstSimMapper._nbit_patch = 5
         LsstSimMapper._nbit_filter = 6
-        LsstSimMapper._nbit_id = 64 - (LsstSimMapper._nbit_tract + \
-                                       2 * LsstSimMapper._nbit_patch + \
+        LsstSimMapper._nbit_id = 64 - (LsstSimMapper._nbit_tract +
+                                       2 * LsstSimMapper._nbit_patch +
                                        LsstSimMapper._nbit_filter)
-
 
     def _transformId(self, dataId):
         """Transform an ID dict into standard form for LSST
@@ -228,14 +226,14 @@ class LsstSimMapper(CameraMapper):
                                    filter coadd, in which case dataId
                                    must contain filter.
         """
-                # taken from hscMapper.py                                                                                     |
+        # taken from hscMapper.py    |
         tract = int(dataId['tract'])
         if tract < 0 or tract >= 2**LsstSimMapper._nbit_tract:
             raise RuntimeError('tract not in range [0,%d)' % (2**LsstSimMapper._nbit_tract))
         patchX, patchY = [int(patch) for patch in dataId['patch'].split(',')]
         for p in (patchX, patchY):
             if p < 0 or p >= 2**LsstSimMapper._nbit_patch:
-                raise RuntimeError('patch component not in range [0, %d)' % \
+                raise RuntimeError('patch component not in range [0, %d)' %
                                    2**LsstSimMapper._nbit_patch)
         oid = (((tract << LsstSimMapper._nbit_patch) + patchX) << LsstSimMapper._nbit_patch) + patchY
         if singleFilter:

--- a/tests/test_getId.py
+++ b/tests/test_getId.py
@@ -57,9 +57,14 @@ class GetIdTestCase(unittest.TestCase):
         bits = self.butler.get("deepCoaddId_bits", dataId, immediate=True)
         id = self.butler.get("deepCoaddId", dataId, immediate=True)
         self.assertEqual(bits, 37)
-        #self.assertEqual(id, ((((1 * 8192) + 2) * 8192) + 3)*8 + 4)
-        # ((((Tract * 2^5 + PatchX) * 2^5) + PatchY) * 2^6) + Filter
-        self.assertEqual(id, ((((1 * 32) + 2) * 32) + 3)*64 + 4)
+        tract = 1
+        patchx = 2
+        patchy = 3
+        filter = 4
+        # Bit packing used in lsstSimMapper.py is now based on hscMapper.py
+        nbit_patch = 5
+        nbit_filter = 6  
+        self.assertEqual(id, (((((tract << nbit_patch) + patchx) << nbit_patch) + patchy) << nbit_filter) + filter)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_getId.py
+++ b/tests/test_getId.py
@@ -53,18 +53,19 @@ class GetIdTestCase(unittest.TestCase):
         id = dr.get("ccdExposureId")
         self.assertEqual(bits, 41)
         self.assertEqual(id, (85471048 << 9) + 11*10 + 5)
-        dataId = dict(tract=1, patch='2,3', filter='z')
-        bits = self.butler.get("deepCoaddId_bits", dataId, immediate=True)
-        id = self.butler.get("deepCoaddId", dataId, immediate=True)
-        self.assertEqual(bits, 37)
         tract = 1
         patchx = 2
         patchy = 3
-        filter = 4
+        filter_ = 4
+        dataId = dict(tract=tract, patch='{},{}'.format(patchx, patchy), filter='ugrizy'[filter_])
+        bits = self.butler.get("deepCoaddId_bits", dataId, immediate=True)
+        id = self.butler.get("deepCoaddId", dataId, immediate=True)
+        self.assertEqual(bits, 37)
         # Bit packing used in lsstSimMapper.py is now based on hscMapper.py
         nbit_patch = 5
-        nbit_filter = 6  
-        self.assertEqual(id, (((((tract << nbit_patch) + patchx) << nbit_patch) + patchy) << nbit_filter) + filter)
+        nbit_filter = 6
+        self.assertEqual(id, (((((tract << nbit_patch) + patchx) << nbit_patch) + patchy) <<
+                              nbit_filter) + filter_)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_getId.py
+++ b/tests/test_getId.py
@@ -57,7 +57,9 @@ class GetIdTestCase(unittest.TestCase):
         bits = self.butler.get("deepCoaddId_bits", dataId, immediate=True)
         id = self.butler.get("deepCoaddId", dataId, immediate=True)
         self.assertEqual(bits, 37)
-        self.assertEqual(id, ((((1 * 8192) + 2) * 8192) + 3)*8 + 4)
+        #self.assertEqual(id, ((((1 * 8192) + 2) * 8192) + 3)*8 + 4)
+        # ((((Tract * 2^5 + PatchX) * 2^5) + PatchY) * 2^6) + Filter
+        self.assertEqual(id, ((((1 * 32) + 2) * 32) + 3)*64 + 4)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Fixed https://github.com/LSSTDESC/obs_lsstSim/issues/11 and cleared some flake complaints. Now LSSTDESC/obs_lsstSim builds successfully and runs unit tests against w_2018_18.